### PR TITLE
Change dataAtFetch to type SQLLEN

### DIFF
--- a/src/odbctest/fhrslt.c
+++ b/src/odbctest/fhrslt.c
@@ -853,7 +853,7 @@ BOOL INTFUN UpdateBoundColumn(lpCONNECTIONINFO lpCI,UWORD icol,SWORD fCType,
 //| Returns:
 //|	The return code from the function
 //*---------------------------------------------------------------------------------
-static SQLUINTEGER dataAtFetch = SQL_DATA_AT_FETCH;
+static SQLLEN dataAtFetch = SQL_DATA_AT_FETCH;
 RETCODE INTFUN lpSQLBindCol(STD_FH_PARMS)
 {
 	RETCODE					rc;


### PR DESCRIPTION
Parameter `strLenOrIndPtr` for `SQLBindCol()` should be `SQLLEN` as opposed to `SQLUINTEGER`; the latter will cause 32bits of garbage data to be passed to driver under 64-bit mode.