### PR TITLE
Fix the size of handle in SQLAllocHandle

### DIFF
--- a/src/odbctest/fhhndl.c
+++ b/src/odbctest/fhhndl.c
@@ -64,7 +64,7 @@ RETCODE INTFUN lpSQLAllocHandle(STD_FH_PARMS)
 		hInHandle=*(SQLHANDLE *)lpParms[1]->lpData;
 
 	BUILDOUTPUTPARM(lpParms[2], 							// Allocate OutputHandlePtr
-						sizeof(UDWORD),						//  based on cbValueMax
+						sizeof(SQLHANDLE),					//  based on cbValueMax
 						lpUsrOptions->fBufferChecking);
 
 	// Log input parameters


### PR DESCRIPTION
UDWORD is not the correct size of a handle on 64-bit systems and causes crash when attempting to run under pageheap/appverifier; use the SQLHANDLE instead which will be the correct size regardless of the bitness of the system.